### PR TITLE
feat: unified `upload()` API, meeting recording flow, custom headers & gen-AI text (v0.2.16)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,14 +74,15 @@ conn = videodb.connect(api_key="YOUR_API_KEY")
 Now that you have established a connection to VideoDB, you can upload your videos using `conn.upload()`.
 You can directly upload from `youtube`, `any public url`, `S3 bucket` or a `local file path`. A default collection is created when you create your first connection.
 
-`upload` method returns a `Video` object.
+`upload` method returns a `Video` object. You can simply pass a single string
+representing either a local file path or a URL.
 
 ```python
 # Upload a video by url
-video = conn.upload(url="https://www.youtube.com/watch?v=WDv4AWk0J3U")
+video = conn.upload("https://www.youtube.com/watch?v=WDv4AWk0J3U")
 
 # Upload a video from file system
-video_f = conn.upload(file_path="./my_video.mp4")
+video_f = conn.upload("./my_video.mp4")
 
 ```
 
@@ -147,9 +148,9 @@ In the future you'll be able to index videos using:
 coll = conn.get_collection()
 
 # Upload Videos to a collection
-coll.upload(url="https://www.youtube.com/watch?v=lsODSDmY4CY")
-coll.upload(url="https://www.youtube.com/watch?v=vZ4kOr38JhY")
-coll.upload(url="https://www.youtube.com/watch?v=uak_dXHh6s4")
+coll.upload("https://www.youtube.com/watch?v=lsODSDmY4CY")
+coll.upload("https://www.youtube.com/watch?v=vZ4kOr38JhY")
+coll.upload("https://www.youtube.com/watch?v=uak_dXHh6s4")
 ```
 
 - `conn.get_collection()` : Returns a Collection object; the default collection.

--- a/videodb/__about__.py
+++ b/videodb/__about__.py
@@ -1,8 +1,6 @@
-""" About information for videodb sdk"""
+"""About information for videodb sdk"""
 
-
-
-__version__ = "0.2.15"
+__version__ = "0.2.16"
 __title__ = "videodb"
 __author__ = "videodb"
 __email__ = "contact@videodb.io"

--- a/videodb/__init__.py
+++ b/videodb/__init__.py
@@ -58,6 +58,7 @@ def connect(
     api_key: str = None,
     base_url: Optional[str] = VIDEO_DB_API,
     log_level: Optional[int] = logging.INFO,
+    **kwargs,
 ) -> Connection:
     """A client for interacting with a videodb via REST API
 
@@ -76,4 +77,4 @@ def connect(
             "No API key provided. Set an API key either as an environment variable (VIDEO_DB_API_KEY) or pass it as an argument."
         )
 
-    return Connection(api_key, base_url)
+    return Connection(api_key, base_url, **kwargs)

--- a/videodb/_constants.py
+++ b/videodb/_constants.py
@@ -91,6 +91,12 @@ class Status:
     in_progress = "in progress"
 
 
+class MeetingStatus:
+    initializing = "initializing"
+    processing = "processing"
+    done = "done"
+
+
 class HttpClientDefaultValues:
     max_retries = 1
     timeout = 30

--- a/videodb/_constants.py
+++ b/videodb/_constants.py
@@ -77,6 +77,7 @@ class ApiPath:
     alert = "alert"
     generate_url = "generate_url"
     generate = "generate"
+    text = "text"
     web = "web"
     translate = "translate"
     dub = "dub"

--- a/videodb/_constants.py
+++ b/videodb/_constants.py
@@ -81,6 +81,8 @@ class ApiPath:
     translate = "translate"
     dub = "dub"
     transcode = "transcode"
+    meeting = "meeting"
+    record = "record"
 
 
 class Status:

--- a/videodb/_upload.py
+++ b/videodb/_upload.py
@@ -1,7 +1,9 @@
 import requests
 
 from typing import Optional
+from urllib.parse import urlparse
 from requests import HTTPError
+import os
 
 
 from videodb._constants import (
@@ -13,15 +15,42 @@ from videodb.exceptions import (
 )
 
 
+def _is_url(path: str) -> bool:
+    parsed = urlparse(path)
+    return all([parsed.scheme in ("http", "https"), parsed.netloc])
+
+
 def upload(
     _connection,
-    file_path: str = None,
-    url: str = None,
+    source: Optional[str] = None,
     media_type: Optional[str] = None,
     name: Optional[str] = None,
     description: Optional[str] = None,
     callback_url: Optional[str] = None,
+    file_path: Optional[str] = None,
+    url: Optional[str] = None,
 ) -> dict:
+    """Upload a file or URL.
+
+    ``source`` can be used as a generic argument which accepts either a local
+    file path or a URL.
+    """
+    if source and (file_path or url):
+        raise VideodbError("source cannot be used with file_path or url")
+
+    if source and not file_path and not url:
+        if _is_url(source):
+            url = source
+        else:
+            file_path = source
+    if file_path and not url and _is_url(file_path):
+        url = file_path
+        file_path = None
+
+    if not file_path and url and not _is_url(url) and os.path.exists(url):
+        file_path = url
+        url = None
+
     if not file_path and not url:
         raise VideodbError("Either file_path or url is required")
     if file_path and url:

--- a/videodb/_upload.py
+++ b/videodb/_upload.py
@@ -32,8 +32,16 @@ def upload(
 ) -> dict:
     """Upload a file or URL.
 
-    ``source`` can be used as a generic argument which accepts either a local
-    file path or a URL.
+    :param _connection: Connection object for API calls
+    :param str source: Local path or URL of the file to be uploaded
+    :param str media_type: MediaType object (optional)
+    :param str name: Name of the file (optional)
+    :param str description: Description of the file (optional)
+    :param str callback_url: URL to receive the callback (optional)
+    :param str file_path: Path to the file to be uploaded
+    :param str url: URL of the file to be uploaded
+    :return: Dictionary containing upload response data
+    :rtype: dict
     """
     if source and (file_path or url):
         raise VideodbError("source cannot be used with file_path or url")

--- a/videodb/_utils/_http_client.py
+++ b/videodb/_utils/_http_client.py
@@ -34,6 +34,7 @@ class HttpClient:
         base_url: str,
         version: str,
         max_retries: Optional[int] = HttpClientDefaultValues.max_retries,
+        **kwargs,
     ) -> None:
         """Create a new http client instance
 
@@ -52,11 +53,13 @@ class HttpClient:
         self.session.mount("http://", adapter)
         self.session.mount("https://", adapter)
         self.version = version
+        kwargs = self._format_headers(kwargs)
         self.session.headers.update(
             {
                 "x-access-token": api_key,
                 "x-videodb-client": f"videodb-python/{self.version}",
                 "Content-Type": "application/json",
+                **kwargs,
             }
         )
         self.base_url = base_url
@@ -197,6 +200,14 @@ class HttpClient:
             raise InvalidRequestError(
                 f"Invalid request: {response.text}", response
             ) from None
+
+    def _format_headers(self, headers: dict):
+        """Format the headers"""
+        formatted_headers = {}
+        for key, value in headers.items():
+            key = key.lower().replace("_", "-")
+            formatted_headers[f"x-{key}"] = value
+        return formatted_headers
 
     def get(
         self, path: str, show_progress: Optional[bool] = False, **kwargs

--- a/videodb/client.py
+++ b/videodb/client.py
@@ -256,32 +256,35 @@ class Connection(HttpClient):
 
     def upload(
         self,
-        file_path: str = None,
-        url: str = None,
+        source: Optional[str] = None,
         media_type: Optional[str] = None,
         name: Optional[str] = None,
         description: Optional[str] = None,
         callback_url: Optional[str] = None,
+        file_path: Optional[str] = None,
+        url: Optional[str] = None,
     ) -> Union[Video, Audio, Image, None]:
         """Upload a file.
 
-        :param str file_path: Path to the file to upload (optional)
-        :param str url: URL of the file to upload (optional)
+        :param str source: Local path or URL of the file to upload (optional)
         :param MediaType media_type: MediaType object (optional)
         :param str name: Name of the file (optional)
         :param str description: Description of the file (optional)
         :param str callback_url: URL to receive the callback (optional)
+        :param str file_path: Path to the file to upload (optional) 
+        :param str url: URL of the file to upload (optional) 
         :return: :class:`Video <Video>`, or :class:`Audio <Audio>`, or :class:`Image <Image>` object
         :rtype: Union[ :class:`videodb.video.Video`, :class:`videodb.audio.Audio`, :class:`videodb.image.Image`]
         """
         upload_data = upload(
             self,
-            file_path,
-            url,
-            media_type,
-            name,
-            description,
-            callback_url,
+            source,
+            media_type=media_type,
+            name=name,
+            description=description,
+            callback_url=callback_url,
+            file_path=file_path,
+            url=url,
         )
         media_id = upload_data.get("id", "")
         if media_id.startswith("m-"):

--- a/videodb/client.py
+++ b/videodb/client.py
@@ -302,7 +302,7 @@ class Connection(HttpClient):
         meeting_url: str,
         bot_name: str = None,
         bot_image_url: str = None,
-        meeting_name: str = None,
+        meeting_title: str = None,
         callback_url: str = None,
         callback_data: dict = {},
         time_zone: str = "UTC",
@@ -312,7 +312,7 @@ class Connection(HttpClient):
         :param str meeting_url: Meeting url
         :param str bot_name: Name of the recorder bot
         :param str bot_image_url: URL of the recorder bot image
-        :param str meeting_name: Name of the meeting
+        :param str meeting_title: Name of the meeting
         :param str callback_url: URL to receive callback once recording is done
         :param dict callback_data: Data to be sent in the callback (optional)
         :param str time_zone: Time zone for the meeting (default ``UTC``)
@@ -326,7 +326,7 @@ class Connection(HttpClient):
                 "meeting_url": meeting_url,
                 "bot_name": bot_name,
                 "bot_image_url": bot_image_url,
-                "meeting_name": meeting_name,
+                "meeting_title": meeting_title,
                 "callback_url": callback_url,
                 "callback_data": callback_data,
                 "time_zone": time_zone,

--- a/videodb/client.py
+++ b/videodb/client.py
@@ -304,7 +304,7 @@ class Connection(HttpClient):
         bot_image_url: str = None,
         meeting_title: str = None,
         callback_url: str = None,
-        callback_data: dict = {},
+        callback_data: Optional[dict] = None,
         time_zone: str = "UTC",
     ) -> Meeting:
         """Record a meeting and upload it to the default collection.
@@ -319,6 +319,8 @@ class Connection(HttpClient):
         :return: :class:`Meeting <Meeting>` object representing the recording bot
         :rtype: :class:`videodb.meeting.Meeting`
         """
+        if callback_data is None:
+            callback_data = {}
 
         response = self.post(
             path=f"{ApiPath.collection}/default/{ApiPath.meeting}/{ApiPath.record}",

--- a/videodb/client.py
+++ b/videodb/client.py
@@ -45,7 +45,9 @@ class Connection(HttpClient):
         self.api_key = api_key
         self.base_url = base_url
         self.collection_id = "default"
-        super().__init__(api_key=api_key, base_url=base_url, version=__version__, **kwargs)
+        super().__init__(
+            api_key=api_key, base_url=base_url, version=__version__, **kwargs
+        )
 
     def get_collection(self, collection_id: Optional[str] = "default") -> Collection:
         """Get a collection object by its ID.
@@ -272,8 +274,8 @@ class Connection(HttpClient):
         :param str name: Name of the file (optional)
         :param str description: Description of the file (optional)
         :param str callback_url: URL to receive the callback (optional)
-        :param str file_path: Path to the file to upload (optional) 
-        :param str url: URL of the file to upload (optional) 
+        :param str file_path: Path to the file to upload (optional)
+        :param str url: URL of the file to upload (optional)
         :return: :class:`Video <Video>`, or :class:`Audio <Audio>`, or :class:`Image <Image>` object
         :rtype: Union[ :class:`videodb.video.Video`, :class:`videodb.audio.Audio`, :class:`videodb.image.Image`]
         """
@@ -298,9 +300,10 @@ class Connection(HttpClient):
     def record_meeting(
         self,
         link: str,
-        bot_name: str,
-        meeting_name: str,
-        callback_url: str,
+        bot_name: str = None,
+        bot_image_url: str = None,
+        meeting_name: str = None,
+        callback_url: str = None,
         callback_data: dict = {},
         time_zone: str = "UTC",
     ) -> Meeting:
@@ -308,6 +311,7 @@ class Connection(HttpClient):
 
         :param str link: Meeting link
         :param str bot_name: Name of the recorder bot
+        :param str bot_image_url: URL of the recorder bot image
         :param str meeting_name: Name of the meeting
         :param str callback_url: URL to receive callback once recording is done
         :param dict callback_data: Data to be sent in the callback (optional)
@@ -321,6 +325,7 @@ class Connection(HttpClient):
             data={
                 "link": link,
                 "bot_name": bot_name,
+                "bot_image_url": bot_image_url,
                 "meeting_name": meeting_name,
                 "callback_url": callback_url,
                 "callback_data": callback_data,
@@ -329,3 +334,14 @@ class Connection(HttpClient):
         )
         meeting_id = response.get("meeting_id")
         return Meeting(self, id=meeting_id, collection_id="default", **response)
+
+    def get_meeting(self, meeting_id: str) -> Meeting:
+        """Get a meeting by its ID.
+
+        :param str meeting_id: ID of the meeting
+        :return: :class:`Meeting <Meeting>` object
+        :rtype: :class:`videodb.meeting.Meeting`
+        """
+        meeting = Meeting(self, id=meeting_id, collection_id="default")
+        meeting.refresh()
+        return meeting

--- a/videodb/client.py
+++ b/videodb/client.py
@@ -299,7 +299,7 @@ class Connection(HttpClient):
 
     def record_meeting(
         self,
-        link: str,
+        meeting_url: str,
         bot_name: str = None,
         bot_image_url: str = None,
         meeting_name: str = None,
@@ -309,7 +309,7 @@ class Connection(HttpClient):
     ) -> Meeting:
         """Record a meeting and upload it to the default collection.
 
-        :param str link: Meeting link
+        :param str meeting_url: Meeting url
         :param str bot_name: Name of the recorder bot
         :param str bot_image_url: URL of the recorder bot image
         :param str meeting_name: Name of the meeting
@@ -323,7 +323,7 @@ class Connection(HttpClient):
         response = self.post(
             path=f"{ApiPath.collection}/default/{ApiPath.meeting}/{ApiPath.record}",
             data={
-                "link": link,
+                "meeting_url": meeting_url,
                 "bot_name": bot_name,
                 "bot_image_url": bot_image_url,
                 "meeting_name": meeting_name,

--- a/videodb/collection.py
+++ b/videodb/collection.py
@@ -520,7 +520,7 @@ class Collection:
         bot_image_url: str = None,
         meeting_title: str = None,
         callback_url: str = None,
-        callback_data: dict = {},
+        callback_data: Optional[dict] = None,
         time_zone: str = "UTC",
     ) -> Meeting:
         """Record a meeting and upload it to this collection.
@@ -535,6 +535,8 @@ class Collection:
         :return: :class:`Meeting <Meeting>` object representing the recording bot
         :rtype: :class:`videodb.meeting.Meeting`
         """
+        if callback_data is None:
+            callback_data = {}
 
         response = self._connection.post(
             path=f"{ApiPath.collection}/{self.id}/{ApiPath.meeting}/{ApiPath.record}",

--- a/videodb/collection.py
+++ b/videodb/collection.py
@@ -358,6 +358,30 @@ class Collection:
         if video_data:
             return Video(self._connection, **video_data)
 
+    def generate_text(
+        self,
+        prompt: str,
+        model_name: Literal["basic", "pro", "ultra"] = "basic",
+        response_type: Literal["text", "json"] = "text",
+    ) -> Union[str, dict]:
+        """Generate text from a prompt using genai offering.
+
+        :param str prompt: Prompt for the text generation
+        :param str model_name: Model name to use ("basic", "pro" or "ultra")
+        :param str response_type: Desired response type ("text" or "json")
+        :return: Generated text response
+        :rtype: Union[str, dict]
+        """
+
+        return self._connection.post(
+            path=f"{ApiPath.collection}/{self.id}/{ApiPath.generate}/{ApiPath.text}",
+            data={
+                "prompt": prompt,
+                "model_name": model_name,
+                "response_type": response_type,
+            },
+        )
+
     def dub_video(
         self, video_id: str, language_code: str, callback_url: Optional[str] = None
     ) -> Video:

--- a/videodb/collection.py
+++ b/videodb/collection.py
@@ -12,6 +12,7 @@ from videodb._constants import (
 from videodb.video import Video
 from videodb.audio import Audio
 from videodb.image import Image
+from videodb.meeting import Meeting
 from videodb.rtstream import RTStream
 from videodb.search import SearchFactory, SearchResult
 
@@ -487,3 +488,38 @@ class Collection:
             path=f"{ApiPath.collection}/{self.id}", data={"is_public": False}
         )
         self.is_public = False
+
+    def record_meeting(
+        self,
+        link: str,
+        bot_name: str = None,
+        meeting_name: str = None,
+        callback_url: str = None,
+        callback_data: dict = {},
+        time_zone: str = "UTC",
+    ) -> Meeting:
+        """Record a meeting and upload it to this collection.
+
+        :param str link: Meeting link
+        :param str bot_name: Name of the recorder bot
+        :param str meeting_name: Name of the meeting
+        :param str callback_url: URL to receive callback once recording is done
+        :param dict callback_data: Data to be sent in the callback (optional)
+        :param str time_zone: Time zone for the meeting (default ``UTC``)
+        :return: :class:`Meeting <Meeting>` object representing the recording bot
+        :rtype: :class:`videodb.meeting.Meeting`
+        """
+
+        response = self._connection.post(
+            path=f"{ApiPath.collection}/{self.id}/{ApiPath.meeting}/{ApiPath.record}",
+            data={
+                "link": link,
+                "bot_name": bot_name,
+                "meeting_name": meeting_name,
+                "callback_url": callback_url,
+                "callback_data": callback_data,
+                "time_zone": time_zone,
+            },
+        )
+        meeting_id = response.get("meeting_id")
+        return Meeting(self._connection, id=meeting_id, collection_id=self.id, **response)

--- a/videodb/collection.py
+++ b/videodb/collection.py
@@ -518,7 +518,7 @@ class Collection:
         meeting_url: str,
         bot_name: str = None,
         bot_image_url: str = None,
-        meeting_name: str = None,
+        meeting_title: str = None,
         callback_url: str = None,
         callback_data: dict = {},
         time_zone: str = "UTC",
@@ -528,7 +528,7 @@ class Collection:
         :param str meeting_url: Meeting url
         :param str bot_name: Name of the recorder bot
         :param str bot_image_url: URL of the recorder bot image
-        :param str meeting_name: Name of the meeting
+        :param str meeting_title: Name of the meeting
         :param str callback_url: URL to receive callback once recording is done
         :param dict callback_data: Data to be sent in the callback (optional)
         :param str time_zone: Time zone for the meeting (default ``UTC``)
@@ -542,7 +542,7 @@ class Collection:
                 "meeting_url": meeting_url,
                 "bot_name": bot_name,
                 "bot_image_url": bot_image_url,
-                "meeting_name": meeting_name,
+                "meeting_title": meeting_title,
                 "callback_url": callback_url,
                 "callback_data": callback_data,
                 "time_zone": time_zone,

--- a/videodb/collection.py
+++ b/videodb/collection.py
@@ -428,32 +428,35 @@ class Collection:
 
     def upload(
         self,
-        file_path: str = None,
-        url: Optional[str] = None,
+        source: Optional[str] = None,
         media_type: Optional[str] = None,
         name: Optional[str] = None,
         description: Optional[str] = None,
         callback_url: Optional[str] = None,
+        file_path: Optional[str] = None,
+        url: Optional[str] = None,
     ) -> Union[Video, Audio, Image, None]:
         """Upload a file to the collection.
 
-        :param str file_path: Path to the file to be uploaded
-        :param str url: URL of the file to be uploaded
+        :param str source: Local path or URL of the file to be uploaded
         :param MediaType media_type: MediaType object (optional)
         :param str name: Name of the file (optional)
         :param str description: Description of the file (optional)
         :param str callback_url: URL to receive the callback (optional)
+        :param str file_path: Path to the file to be uploaded
+        :param str url: URL of the file to be uploaded
         :return: :class:`Video <Video>`, or :class:`Audio <Audio>`, or :class:`Image <Image>` object
         :rtype: Union[ :class:`videodb.video.Video`, :class:`videodb.audio.Audio`, :class:`videodb.image.Image`]
         """
         upload_data = upload(
             self._connection,
-            file_path,
-            url,
-            media_type,
-            name,
-            description,
-            callback_url,
+            source,
+            media_type=media_type,
+            name=name,
+            description=description,
+            callback_url=callback_url,
+            file_path=file_path,
+            url=url,
         )
         media_id = upload_data.get("id", "")
         if media_id.startswith("m-"):

--- a/videodb/collection.py
+++ b/videodb/collection.py
@@ -515,7 +515,7 @@ class Collection:
 
     def record_meeting(
         self,
-        link: str,
+        meeting_url: str,
         bot_name: str = None,
         bot_image_url: str = None,
         meeting_name: str = None,
@@ -525,7 +525,7 @@ class Collection:
     ) -> Meeting:
         """Record a meeting and upload it to this collection.
 
-        :param str link: Meeting link
+        :param str meeting_url: Meeting url
         :param str bot_name: Name of the recorder bot
         :param str bot_image_url: URL of the recorder bot image
         :param str meeting_name: Name of the meeting
@@ -539,7 +539,7 @@ class Collection:
         response = self._connection.post(
             path=f"{ApiPath.collection}/{self.id}/{ApiPath.meeting}/{ApiPath.record}",
             data={
-                "link": link,
+                "meeting_url": meeting_url,
                 "bot_name": bot_name,
                 "bot_image_url": bot_image_url,
                 "meeting_name": meeting_name,

--- a/videodb/collection.py
+++ b/videodb/collection.py
@@ -517,6 +517,7 @@ class Collection:
         self,
         link: str,
         bot_name: str = None,
+        bot_image_url: str = None,
         meeting_name: str = None,
         callback_url: str = None,
         callback_data: dict = {},
@@ -526,6 +527,7 @@ class Collection:
 
         :param str link: Meeting link
         :param str bot_name: Name of the recorder bot
+        :param str bot_image_url: URL of the recorder bot image
         :param str meeting_name: Name of the meeting
         :param str callback_url: URL to receive callback once recording is done
         :param dict callback_data: Data to be sent in the callback (optional)
@@ -539,6 +541,7 @@ class Collection:
             data={
                 "link": link,
                 "bot_name": bot_name,
+                "bot_image_url": bot_image_url,
                 "meeting_name": meeting_name,
                 "callback_url": callback_url,
                 "callback_data": callback_data,
@@ -546,4 +549,17 @@ class Collection:
             },
         )
         meeting_id = response.get("meeting_id")
-        return Meeting(self._connection, id=meeting_id, collection_id=self.id, **response)
+        return Meeting(
+            self._connection, id=meeting_id, collection_id=self.id, **response
+        )
+
+    def get_meeting(self, meeting_id: str) -> Meeting:
+        """Get a meeting by its ID.
+
+        :param str meeting_id: ID of the meeting
+        :return: :class:`Meeting <Meeting>` object
+        :rtype: :class:`videodb.meeting.Meeting`
+        """
+        meeting = Meeting(self._connection, id=meeting_id, collection_id=self.id)
+        meeting.refresh()
+        return meeting

--- a/videodb/meeting.py
+++ b/videodb/meeting.py
@@ -24,6 +24,8 @@ class Meeting:
         self.meeting_url = data.get("meeting_url")
         self.status = data.get("status")
         self.time_zone = data.get("time_zone")
+        self.video_id = data.get("video_id")
+        self.speaker_timeline = data.get("speaker_timeline")
 
     def refresh(self) -> "Meeting":
         """Refresh meeting data from the server.

--- a/videodb/meeting.py
+++ b/videodb/meeting.py
@@ -4,6 +4,9 @@ from videodb.exceptions import (
     VideodbError,
 )
 
+DEFAULT_MEETING_TIMEOUT = 14400  # 4 hours
+DEFAULT_POLLING_INTERVAL = 120  # 2 minutes
+
 
 class Meeting:
     """Meeting class representing a meeting recording bot.
@@ -80,7 +83,10 @@ class Meeting:
         return self.status == MeetingStatus.done
 
     def wait_for_status(
-        self, target_status: str, timeout: int = 14400, interval: int = 120
+        self,
+        target_status: str,
+        timeout: int = DEFAULT_MEETING_TIMEOUT,
+        interval: int = DEFAULT_POLLING_INTERVAL,
     ) -> bool:
         """Wait for the meeting to reach a specific status.
 

--- a/videodb/meeting.py
+++ b/videodb/meeting.py
@@ -11,7 +11,7 @@ class Meeting:
     :ivar str id: Unique identifier for the meeting
     :ivar str collection_id: ID of the collection this meeting belongs to
     :ivar str bot_name: Name of the meeting recording bot
-    :ivar str name: Name of the meeting
+    :ivar str meeting_title: Title of the meeting
     :ivar str meeting_url: URL of the meeting
     :ivar str status: Current status of the meeting
     :ivar str time_zone: Time zone of the meeting
@@ -26,7 +26,7 @@ class Meeting:
         self._update_attributes(kwargs)
 
     def __repr__(self) -> str:
-        return f"Meeting(id={self.id}, collection_id={self.collection_id}, name={self.name}, status={self.status}, bot_name={self.bot_name}, meeting_url={self.meeting_url})"
+        return f"Meeting(id={self.id}, collection_id={self.collection_id}, meeting_title={self.meeting_title}, status={self.status}, bot_name={self.bot_name}, meeting_url={self.meeting_url})"
 
     def _update_attributes(self, data: dict) -> None:
         """Update instance attributes from API response data.
@@ -36,7 +36,7 @@ class Meeting:
         :rtype: None
         """
         self.bot_name = data.get("bot_name")
-        self.name = data.get("meeting_name")
+        self.meeting_title = data.get("meeting_title")
         self.meeting_url = data.get("meeting_url")
         self.status = data.get("status")
         self.time_zone = data.get("time_zone")

--- a/videodb/meeting.py
+++ b/videodb/meeting.py
@@ -1,0 +1,81 @@
+from videodb._constants import ApiPath
+
+from videodb.exceptions import (
+    VideodbError,
+)
+
+
+class Meeting:
+    """Meeting class representing a meeting recording bot."""
+
+    def __init__(self, _connection, id: str, collection_id: str, **kwargs) -> None:
+        self._connection = _connection
+        self.id = id
+        self.collection_id = collection_id
+        self._update_attributes(kwargs)
+
+    def __repr__(self) -> str:
+        return f"Meeting(id={self.id}, collection_id={self.collection_id}, name={self.name}, status={self.status}, bot_name={self.bot_name})"
+
+    def _update_attributes(self, data: dict) -> None:
+        """Update instance attributes from API response data."""
+        self.bot_name = data.get("bot_name")
+        self.name = data.get("meeting_name")
+        self.meeting_url = data.get("meeting_url")
+        self.status = data.get("status")
+        self.time_zone = data.get("time_zone")
+
+    def refresh(self) -> "Meeting":
+        """Refresh meeting data from the server.
+
+        Returns:
+            self: The Meeting instance with updated data
+
+        Raises:
+            APIError: If the API request fails
+        """
+        response = self._connection.get(
+            path=f"{ApiPath.collection}/{self.collection_id}/{ApiPath.meeting}/{self.id}"
+        )
+
+        if response:
+            self._update_attributes(response)
+        else:
+            raise VideodbError(f"Failed to refresh meeting {self.id}")
+
+        return self
+
+    @property
+    def is_active(self) -> bool:
+        """Check if the meeting is currently active."""
+        return self.status in ["initializing", "processing"]
+
+    @property
+    def is_completed(self) -> bool:
+        """Check if the meeting has completed."""
+        return self.status in ["done"]
+
+    def wait_for_status(
+        self, target_status: str, timeout: int = 14400, interval: int = 120
+    ) -> bool:
+        """Wait for the meeting to reach a specific status.
+
+        Args:
+            target_status: The status to wait for
+            timeout: Maximum time to wait in seconds
+            interval: Time between status checks in seconds
+
+        Returns:
+            bool: True if status reached, False if timeout
+        """
+        import time
+
+        start_time = time.time()
+
+        while time.time() - start_time < timeout:
+            self.refresh()
+            if self.status == target_status:
+                return True
+            time.sleep(interval)
+
+        return False

--- a/videodb/meeting.py
+++ b/videodb/meeting.py
@@ -26,7 +26,7 @@ class Meeting:
         self._update_attributes(kwargs)
 
     def __repr__(self) -> str:
-        return f"Meeting(id={self.id}, collection_id={self.collection_id}, name={self.name}, status={self.status}, bot_name={self.bot_name})"
+        return f"Meeting(id={self.id}, collection_id={self.collection_id}, name={self.name}, status={self.status}, bot_name={self.bot_name}, meeting_url={self.meeting_url})"
 
     def _update_attributes(self, data: dict) -> None:
         """Update instance attributes from API response data.

--- a/videodb/video.py
+++ b/videodb/video.py
@@ -249,6 +249,30 @@ class Video:
         )
         return self.transcript_text
 
+    def generate_transcript(
+        self,
+        force: bool = None,
+    ) -> str:
+        """Generate transcript for the video.
+
+        :param bool force: Force generate new transcript
+        :return: Full transcript text as string
+        :rtype: str
+        """
+        transcript_data = self._connection.post(
+            path=f"{ApiPath.video}/{self.id}/{ApiPath.transcription}",
+            data={
+                "force": True if force else False,
+            },
+        )
+        transcript = transcript_data.get("word_timestamps", [])
+        if transcript:
+            return {
+                "success": True,
+                "message": "Transcript generated successfully",
+            }
+        return transcript_data
+
     def translate_transcript(
         self,
         language: str,

--- a/videodb/video.py
+++ b/videodb/video.py
@@ -608,3 +608,29 @@ class Video:
         :rtype: str
         """
         return play_stream(self.stream_url)
+
+    def get_meeting(self):
+        """Get meeting information associated with the video.
+
+        :return: :class:`Meeting <Meeting>` object if meeting is associated, None otherwise
+        :rtype: Optional[:class:`videodb.meeting.Meeting`]
+        :raises InvalidRequestError: If the API request fails
+        """
+        # TODO: Add type check for Meeting
+        from videodb.meeting import Meeting
+
+        try:
+            meeting_data = self._connection.get(
+                path=f"{ApiPath.video}/{self.id}/{ApiPath.meeting}"
+            )
+            if meeting_data:
+                return Meeting(
+                    self._connection,
+                    id=meeting_data.get("meeting_id"),
+                    collection_id=self.collection_id,
+                    **meeting_data,
+                )
+            return None
+        except Exception:
+            # Return None if no meeting is associated or API call fails
+            return None

--- a/videodb/video.py
+++ b/videodb/video.py
@@ -619,18 +619,14 @@ class Video:
         # TODO: Add type check for Meeting
         from videodb.meeting import Meeting
 
-        try:
-            meeting_data = self._connection.get(
-                path=f"{ApiPath.video}/{self.id}/{ApiPath.meeting}"
+        meeting_data = self._connection.get(
+            path=f"{ApiPath.video}/{self.id}/{ApiPath.meeting}"
+        )
+        if meeting_data:
+            return Meeting(
+                self._connection,
+                id=meeting_data.get("meeting_id"),
+                collection_id=self.collection_id,
+                **meeting_data,
             )
-            if meeting_data:
-                return Meeting(
-                    self._connection,
-                    id=meeting_data.get("meeting_id"),
-                    collection_id=self.collection_id,
-                    **meeting_data,
-                )
-            return None
-        except Exception:
-            # Return None if no meeting is associated or API call fails
-            return None
+        return None


### PR DESCRIPTION
## ✨  What’s new in v0.2.16

| Area | Change |
|------|--------|
| **API surface** | • **Unified `upload()` signature** — pass a single string (`source`) or keep using `file_path` / `url` kwargs.<br>• Added **`generate_text()`** on `Collection` for Gen-AI prompts.<br>• Added **`record_meeting()`** on both `Connection` and `Collection`. |
| **New model** | Introduced **`Meeting`** class to track live-call recordings (status polling, helpers, etc.). |
| **HTTP client** | `connect(**kwargs)` now accepts arbitrary header overrides → propagated to `_http_client` via `x-<header>` convention. |
| **Constants** | Added `text`, `meeting`, `record` to `ApiPath`. |
| **Docs / examples** | README examples simplified (`conn.upload("...")`, `coll.upload("...")`). |
| **Version** | Bumped to **0.2.16** in `__about__.py`. |

---

## 🛠  Details

### 1. Unified Upload Flow  
*Why?* To make the SDK feel as “Pythonic” as possible while retaining full backward compatibility.

*Highlights*
* New helper `_is_url()` and smarter path/url detection.
* New positional `source` arg; legacy `file_path`/`url` kwargs still work.
* README code blocks updated accordingly.

### 2. Meeting Recording End-to-End  
* New `Meeting` model with `refresh()`, `is_active`, `wait_for_status()` helpers.  
* `Connection.record_meeting()` and `Collection.record_meeting()` POST to  
  `/collection/<id>/meeting/record` and return a `Meeting` instance.

### 3. Gen-AI Text Generation  
`Collection.generate_text(prompt, model_name="basic" | "pro" | "ultra", response_type="text" | "json")` hits `/generate/text`.

### 4. Custom Headers Support  
`connect(..., my_header="foo")` ⇒ request header `X-My-Header: foo`.  
Includes `_format_headers()` for snake_case → http-header mapping.

---

## 🔄  Backwards Compatibility

* All previous `upload(file_path=..., url=...)` calls still function unchanged.  
* No breaking changes to existing classes or endpoints.