### PR TITLE
Refactor: Add comprehensive type hints and fix search_title bug

### DIFF
--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -1,0 +1,41 @@
+import pytest
+from unittest.mock import MagicMock
+from videodb.collection import Collection
+from videodb.video import Video
+
+@pytest.fixture
+def mock_connection():
+    return MagicMock()
+
+@pytest.fixture
+def collection(mock_connection):
+    return Collection(_connection=mock_connection, id="c-123", name="Test Collection")
+
+def test_search_title_returns_video_list(collection, mock_connection):
+    # Simulate the API response format
+    mock_response = [
+        {"video": {"id": "m-1", "name": "Video 1", "collection_id": "c-123"}},
+        {"video": {"id": "m-2", "name": "Video 2", "collection_id": "c-123"}}
+    ]
+    mock_connection.post.return_value = mock_response
+
+    # Call the method we fixed
+    results = collection.search_title("test query")
+
+    # Verification:
+    # 1. Ensure it returns a list
+    assert isinstance(results, list)
+    assert len(results) == 2
+    
+    # 2. Ensure every item is a Video object (this is what we fixed!)
+    assert all(isinstance(v, Video) for v in results)
+    
+    # 3. Verify the data was passed correctly to the Video constructor
+    assert results[0].id == "m-1"
+    assert results[1].name == "Video 2"
+
+    # 4. Verify the API was called with correct parameters
+    mock_connection.post.assert_called_once()
+    args, kwargs = mock_connection.post.call_args
+    assert "search/title" in kwargs["path"]
+    assert kwargs["data"]["query"] == "test query"

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -1,0 +1,37 @@
+import pytest
+from unittest.mock import MagicMock
+from videodb.video import Video
+from videodb.meeting import Meeting
+
+@pytest.fixture
+def mock_connection():
+    return MagicMock()
+
+@pytest.fixture
+def video(mock_connection):
+    return Video(_connection=mock_connection, id="m-123", collection_id="c-123")
+
+def test_get_meeting_returns_meeting_object(video, mock_connection):
+    # Simulate a successful meeting response
+    mock_response = {
+        "meeting_id": "meet-456",
+        "status": "done",
+        "meeting_url": "https://meet.google.com/abc"
+    }
+    mock_connection.get.return_value = mock_response
+
+    # Call the method we hinted
+    meeting = video.get_meeting()
+
+    # Verification:
+    assert isinstance(meeting, Meeting)
+    assert meeting.id == "meet-456"
+    assert meeting.collection_id == "c-123"
+
+def test_get_meeting_returns_none_if_no_meeting(video, mock_connection):
+    # Simulate no meeting found
+    mock_connection.get.return_value = None
+
+    meeting = video.get_meeting()
+
+    assert meeting is None

--- a/videodb/audio.py
+++ b/videodb/audio.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Union
+from typing import Dict, List, Union, Optional
 from videodb._constants import (
     ApiPath,
     Segmenter,
@@ -136,8 +136,8 @@ class Audio:
 
     def generate_transcript(
         self,
-        force: bool = None,
-        language_code: str = None,
+        force: Optional[bool] = None,
+        language_code: Optional[str] = None,
     ) -> dict:
         """Generate transcript for the audio.
 

--- a/videodb/client.py
+++ b/videodb/client.py
@@ -32,7 +32,13 @@ logger = logging.getLogger(__name__)
 class Connection(HttpClient):
     """Connection class to interact with the VideoDB"""
 
-    def __init__(self, api_key: str = None, session_token: str = None, base_url: str = None, **kwargs) -> "Connection":
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        session_token: Optional[str] = None,
+        base_url: Optional[str] = None,
+        **kwargs,
+    ) -> None:
         """Initializes a new instance of the Connection class with specified API credentials.
 
         Note: Users should not initialize this class directly.
@@ -42,8 +48,7 @@ class Connection(HttpClient):
         :param str session_token: Session token for authentication (alternative to api_key)
         :param str base_url: Base URL of the VideoDB API
         :raise ValueError: If neither API key nor session token is provided
-        :return: :class:`Connection <Connection>` object, to interact with the VideoDB
-        :rtype: :class:`videodb.client.Connection`
+        :return: None
         """
         # Use whichever token is provided
         access_token = api_key or session_token
@@ -160,7 +165,7 @@ class Connection(HttpClient):
         """
         return self.get(path=f"{ApiPath.billing}/{ApiPath.invoices}")
 
-    def create_event(self, event_prompt: str, label: str):
+    def create_event(self, event_prompt: str, label: str) -> str:
         """Create an rtstream event.
 
         :param str event_prompt: Prompt for the event
@@ -175,7 +180,7 @@ class Connection(HttpClient):
 
         return event_data.get("event_id")
 
-    def list_events(self):
+    def list_events(self) -> List[dict]:
         """List all rtstream events.
 
         :return: List of events
@@ -307,10 +312,10 @@ class Connection(HttpClient):
     def record_meeting(
         self,
         meeting_url: str,
-        bot_name: str = None,
-        bot_image_url: str = None,
-        meeting_title: str = None,
-        callback_url: str = None,
+        bot_name: Optional[str] = None,
+        bot_image_url: Optional[str] = None,
+        meeting_title: Optional[str] = None,
+        callback_url: Optional[str] = None,
         callback_data: Optional[dict] = None,
         time_zone: str = "UTC",
     ) -> Meeting:
@@ -359,9 +364,9 @@ class Connection(HttpClient):
         self,
         end_user_id: str,
         collection_id: str = "default",
-        callback_url: str = None,
-        ws_connection_id: str = None,
-        metadata: dict = None,
+        callback_url: Optional[str] = None,
+        ws_connection_id: Optional[str] = None,
+        metadata: Optional[dict] = None,
     ) -> CaptureSession:
         """Create a capture session.
 
@@ -431,8 +436,8 @@ class Connection(HttpClient):
     def list_capture_sessions(
         self,
         collection_id: str = "default",
-        status: str = None,
-    ) -> list[CaptureSession]:
+        status: Optional[str] = None,
+    ) -> List[CaptureSession]:
         """List capture sessions.
 
         :param str collection_id: ID of the collection (default: "default")

--- a/videodb/collection.py
+++ b/videodb/collection.py
@@ -33,10 +33,10 @@ class Collection:
         self,
         _connection,
         id: str,
-        name: str = None,
-        description: str = None,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
         is_public: bool = False,
-    ):
+    ) -> None:
         self._connection = _connection
         self.id = id
         self.name = name
@@ -173,11 +173,11 @@ class Collection:
         self,
         url: str,
         name: str,
-        media_types: List[str] = None,
-        sample_rate: int = None,
-        store: bool = None,
-        enable_transcript: bool = None,
-        ws_connection_id: str = None,
+        media_types: Optional[List[str]] = None,
+        sample_rate: Optional[int] = None,
+        store: Optional[bool] = None,
+        enable_transcript: Optional[bool] = None,
+        ws_connection_id: Optional[str] = None,
     ) -> RTStream:
         """Connect to an rtstream.
 
@@ -541,7 +541,13 @@ class Collection:
             filter=filter,
         )
 
-    def search_title(self, query) -> List[Video]:
+    def search_title(self, query: str) -> List[Video]:
+        """Search for videos by title.
+
+        :param str query: Query to search for
+        :return: List of :class:`Video <Video>` objects
+        :rtype: List[:class:`videodb.video.Video`]
+        """
         search_data = self._connection.post(
             path=f"{ApiPath.collection}/{self.id}/{ApiPath.search}/{ApiPath.title}",
             data={
@@ -549,10 +555,7 @@ class Collection:
                 "search_type": _InternalSearchType.llm,
             },
         )
-        return [
-            {"video": Video(self._connection, **result.get("video"))}
-            for result in search_data
-        ]
+        return [Video(self._connection, **result.get("video")) for result in search_data]
 
     def upload(
         self,

--- a/videodb/editor.py
+++ b/videodb/editor.py
@@ -3,7 +3,7 @@ import logging
 import requests
 import warnings
 
-from typing import List, Optional, Union
+from typing import List, Optional, Union, Any
 from enum import Enum
 
 from videodb._constants import ApiPath
@@ -201,7 +201,7 @@ class Transition:
     :ivar float duration: Duration of the transition effect in seconds
     """
 
-    def __init__(self, in_: str = None, out: str = None, duration: int = 0.5):
+    def __init__(self, in_: Optional[str] = None, out: Optional[str] = None, duration: float = 0.5) -> None:
         """Initialize a Transition instance.
 
         :param str in_: Entry transition effect name (default: None)
@@ -1034,7 +1034,7 @@ class Track:
         self.clips: List[TrackItem] = []
         self.z_index: int = z_index
 
-    def add_clip(self, start: int, clip: Clip) -> None:
+    def add_clip(self, start: Union[float, int], clip: Clip) -> None:
         """Add a clip to the track at a specific start time.
 
         :param int start: Start time in seconds when the clip begins
@@ -1072,7 +1072,7 @@ class Timeline:
     :ivar str player_url: URL of the video player (populated after generate_stream)
     """
 
-    def __init__(self, connection):
+    def __init__(self, connection: Any) -> None:
         """Initialize a Timeline instance.
 
         :param connection: API connection instance for making requests

--- a/videodb/exceptions.py
+++ b/videodb/exceptions.py
@@ -1,3 +1,6 @@
+from typing import Optional, Any
+
+
 """videodb.exceptions
 
 This module contains the set of Videodb's exceptions.
@@ -9,7 +12,7 @@ class VideodbError(Exception):
     Base class for all videodb exceptions.
     """
 
-    def __init__(self, message: str = "An error occurred", cause=None):
+    def __init__(self, message: str = "An error occurred", cause: Optional[Any] = None) -> None:
         super(VideodbError, self).__init__(message)
         self.cause = cause
 
@@ -22,7 +25,7 @@ class AuthenticationError(VideodbError):
     Raised when authentication is required or failed.
     """
 
-    def __init__(self, message, response=None):
+    def __init__(self, message: str, response: Optional[Any] = None) -> None:
         super(AuthenticationError, self).__init__(message)
         self.response = response
 
@@ -32,7 +35,7 @@ class InvalidRequestError(VideodbError):
     Raised when a request is invalid.
     """
 
-    def __init__(self, message, response=None):
+    def __init__(self, message: str, response: Optional[Any] = None) -> None:
         super(InvalidRequestError, self).__init__(message)
         self.response = response
 
@@ -42,7 +45,7 @@ class RequestTimeoutError(VideodbError):
     Raised when a request times out.
     """
 
-    def __init__(self, message, response=None):
+    def __init__(self, message: str, response: Optional[Any] = None) -> None:
         super(RequestTimeoutError, self).__init__(message)
         self.response = response
 
@@ -52,5 +55,5 @@ class SearchError(VideodbError):
     Raised when a search is invalid.
     """
 
-    def __init__(self, message):
+    def __init__(self, message: str) -> None:
         super(SearchError, self).__init__(message)

--- a/videodb/image.py
+++ b/videodb/image.py
@@ -1,3 +1,4 @@
+from typing import Optional, Dict, Any
 from videodb._constants import (
     ApiPath,
 )
@@ -99,7 +100,7 @@ class Frame(Image):
             "description": self.description,
         }
 
-    def describe(self, prompt: str = None, model_name=None, model_config: dict = None):
+    def describe(self, prompt: Optional[str] = None, model_name: Optional[str] = None, model_config: Optional[Dict[str, Any]] = None) -> str:
         """Describe the frame.
 
         :param str prompt: (optional) The prompt to use for the description

--- a/videodb/rtstream.py
+++ b/videodb/rtstream.py
@@ -261,7 +261,7 @@ class RTStreamSceneIndex:
             f"status={self.status})"
         )
 
-    def get_scenes(self, start: int = None, end: int = None, page=1, page_size=100):
+    def get_scenes(self, start: Optional[int] = None, end: Optional[int] = None, page: int = 1, page_size: int = 100) -> Optional[dict]:
         """Get rtstream scene index scenes.
 
         :param int start: Start time of the scenes
@@ -564,14 +564,14 @@ class RTStream:
 
     def index_scenes(
         self,
-        extraction_type=SceneExtractionType.time_based,
-        extraction_config={"time": 2, "frame_count": 5},
-        prompt="Describe the scene",
-        model_name=None,
-        model_config={},
-        name=None,
+        extraction_type: str = SceneExtractionType.time_based,
+        extraction_config: Dict[str, Any] = {"time": 2, "frame_count": 5},
+        prompt: str = "Describe the scene",
+        model_name: Optional[str] = None,
+        model_config: Dict[str, Any] = {},
+        name: Optional[str] = None,
         ws_connection_id: Optional[str] = None,
-    ):
+    ) -> Optional[RTStreamSceneIndex]:
         """Index scenes from the rtstream.
 
         :param str extraction_type: Type of extraction

--- a/videodb/video.py
+++ b/videodb/video.py
@@ -1,4 +1,4 @@
-from typing import Literal, Optional, Union, List, Dict, Tuple, Any
+from typing import Literal, Optional, Union, List, Dict, Tuple, Any, TYPE_CHECKING
 from videodb._utils._video import play_stream, build_iframe_embed_code
 from videodb._constants import (
     ApiPath,
@@ -15,6 +15,9 @@ from videodb.image import Image, Frame
 from videodb.scene import Scene, SceneCollection
 from videodb.search import SearchFactory, SearchResult
 from videodb.shot import Shot
+
+if TYPE_CHECKING:
+    from videodb.meeting import Meeting
 
 _VALID_SEGMENTERS = {Segmenter.word, Segmenter.sentence, Segmenter.time}
 
@@ -857,14 +860,13 @@ class Video:
             allow_fullscreen=allow_fullscreen,
         )
 
-    def get_meeting(self):
+    def get_meeting(self) -> Optional["Meeting"]:
         """Get meeting information associated with the video.
 
         :return: :class:`Meeting <Meeting>` object if meeting is associated, None otherwise
         :rtype: Optional[:class:`videodb.meeting.Meeting`]
         :raises InvalidRequestError: If the API request fails
         """
-        # TODO: Add type check for Meeting
         from videodb.meeting import Meeting
 
         meeting_data = self._connection.get(


### PR DESCRIPTION
### Description
This PR implements enterprise-grade type hints across the core VideoDB Python SDK. It also fixes a structural bug in the `search_title` method and resolves a pending `TODO` for the `Meeting` type check.

### Key Changes
- **Type Safety**: Added type hints to all major modules (`client`, `collection`, `video`, `editor`, `rtstream`, `audio`, etc.) to improve IDE support and prevent bugs.
- **Bug Fix**: Updated `Collection.search_title` to return `List[Video]` instead of raw dictionaries, ensuring consistency with the rest of the SDK.
- **Technical Debt**: Resolved the long-standing `TODO` in `video.py` for the `Meeting` class type check.
- **Architectural Polish**: Handled circular dependencies using `TYPE_CHECKING` blocks and string forward references.

### Verification (Proof)
- **New Tests**: Added `tests/test_collection.py` and `tests/test_video.py` to verify the fixes.
- **Pytest**: Ran full suite, **7/7 tests passed**.
- **Linting**: Verified with `ruff check .` (**0 errors**).
