### PR TITLE
feat: timeline.export() for NLE project bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,6 +495,26 @@ timeline.add_track(audio_track)
 stream_url = timeline.generate_stream()
 ```
 
+**Example: Export as an editable Premiere Pro project**
+
+A timeline can be exported as an NLE bundle instead of a rendered video — the
+cuts, text and captions as a Premiere project, plus the media the sequence
+references. The work takes minutes, so `export()` returns immediately and the job
+is polled.
+
+```python
+job = timeline.export(format="nle", name="My cut")
+
+job.wait()                  # or poll job.refresh() yourself
+if job.done:
+    url = job.download_url()   # signed, minted per call — do not cache it
+    print(job.fidelity)        # what carried over, and what could not
+```
+
+Not everything in a timeline has an equivalent in a project file. `job.fidelity`
+reports per-disposition counts so a successful export that dropped colour grades
+is not reported as a plain success.
+
 **Asset Types:**
 - `VideoAsset` - Video clips with trim control (`start`, `volume`)
 - `AudioAsset` - Background music, voiceovers, sound effects

--- a/README.md
+++ b/README.md
@@ -508,12 +508,13 @@ job = timeline.export(format="nle", name="My cut")
 job.wait()                  # or poll job.refresh() yourself
 if job.done:
     url = job.download_url()   # signed, minted per call — do not cache it
-    print(job.fidelity)        # what carried over, and what could not
+elif job.failed:
+    print(job.error)           # wait() returns on failure too; check which
 ```
 
-Not everything in a timeline has an equivalent in a project file. `job.fidelity`
-reports per-disposition counts so a successful export that dropped colour grades
-is not reported as a plain success.
+Not everything in a timeline has an equivalent in a project file — the bundle
+includes a fidelity report (`fidelity.md`) saying what carried over and what
+could not.
 
 **Asset Types:**
 - `VideoAsset` - Video clips with trim control (`start`, `volume`)

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -239,3 +239,17 @@ def test_a_job_without_a_timeline_says_so_rather_than_guessing():
 def test_the_submitted_job_remembers_its_timeline():
     conn = StubConnection(SUBMITTED)
     assert _timeline(conn).export().timeline_id == "tl-9"
+
+
+def test_download_url_raises_rather_than_returning_none():
+    """The method is annotated `-> str`, so a caller reasonably treats the
+    result as one. Returning None pushes the failure into whatever it is handed
+    to — an opener, an HTTP call, a log line reading "None" — by which point
+    nothing points back at the export that had no bundle.
+    """
+    conn = StubConnection({})  # a download response carrying no URL
+    job = ExportJob(conn, SUBMITTED["job_id"], timeline_id=SUBMITTED["timeline_id"],
+                    status="done")
+
+    with pytest.raises(ValueError, match="no download URL"):
+        job.download_url()

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,0 +1,220 @@
+"""Submitting a timeline for NLE export, and following the job.
+
+The SDK is a pure HTTP client, so all of this is provable against a stub
+connection — no network, no platform, no credentials.
+
+The shape mirrors ``Timeline.generate_stream``, which is the established way this
+SDK asks the platform to do something with a timeline: serialize ``to_json()``,
+POST it inline, and fall back to uploading the JSON when it exceeds
+``MAX_PAYLOAD_SIZE``. Export is the same question as render — "here is a timeline,
+produce an artifact" — so it is the same shape, and the payload-size fallback
+comes along for free rather than being rediscovered the first time somebody
+exports a long timeline.
+"""
+
+import pytest
+
+from videodb.editor import MAX_PAYLOAD_SIZE, Timeline
+from videodb.export import ExportJob
+
+
+class StubConnection:
+    """Records requests and replays scripted responses."""
+
+    def __init__(self, *responses):
+        self._responses = list(responses)
+        self.posts = []
+        self.gets = []
+
+    def post(self, path, data=None, **kwargs):
+        self.posts.append({"path": path, "data": data})
+        return self._next()
+
+    def get(self, path, params=None, **kwargs):
+        self.gets.append({"path": path, "params": params})
+        return self._next()
+
+    def _next(self):
+        return self._responses.pop(0) if self._responses else {}
+
+
+def _timeline(conn):
+    """A bare timeline is enough here.
+
+    These tests are about the request export() builds, not about how tracks are
+    assembled — to_json() produces the same envelope either way, and a populated
+    track would couple them to Track's API for nothing.
+    """
+    return Timeline(conn)
+
+
+SUBMITTED = {"job_id": "exp_abc123def456", "status": "queued", "progress": 0}
+
+
+# ------------------------------------------------------------------- submit
+
+
+def test_export_posts_the_timeline_inline():
+    """The same payload shape generate_stream sends, to a path under `editor`."""
+    conn = StubConnection(SUBMITTED)
+    _timeline(conn).export()
+    assert conn.posts[0]["path"] == "editor/export"
+    assert "timeline" in conn.posts[0]["data"]
+
+
+def test_export_returns_a_job_without_waiting():
+    """An export is minutes of downloads and encoding. A call that blocked by
+    default would make every caller discover that the hard way."""
+    conn = StubConnection(SUBMITTED)
+    job = _timeline(conn).export()
+    assert isinstance(job, ExportJob)
+    assert job.id == "exp_abc123def456"
+    assert job.status == "queued"
+
+
+def test_the_format_is_named_rather_than_assumed():
+    """So a second format is additive rather than a breaking change."""
+    conn = StubConnection(SUBMITTED)
+    _timeline(conn).export()
+    assert conn.posts[0]["data"]["format"] == "nle"
+
+
+def test_optional_fields_are_omitted_rather_than_sent_as_null():
+    """A null `name` is not the same as no name — the service falls back to the
+    timeline id when the key is absent, and to nothing when it is null."""
+    conn = StubConnection(SUBMITTED)
+    _timeline(conn).export()
+    data = conn.posts[0]["data"]
+    assert "name" not in data
+    assert "client_ref" not in data
+    assert "timeline_id" not in data
+
+
+def test_supplied_fields_are_forwarded():
+    conn = StubConnection(SUBMITTED)
+    _timeline(conn).export(name="Demo cut", client_ref="ours-1", timeline_id="tl-9")
+    data = conn.posts[0]["data"]
+    assert data["name"] == "Demo cut"
+    assert data["client_ref"] == "ours-1"
+    assert data["timeline_id"] == "tl-9"
+
+
+def test_a_large_timeline_is_uploaded_rather_than_posted_inline(monkeypatch):
+    """The reason to mirror generate_stream rather than invent a shape.
+
+    These requests cross an API gateway with a hard body cap, so a long timeline
+    posted inline fails at the edge with nothing useful in the response. The
+    render path already solved this; export inherits the solution.
+    """
+    conn = StubConnection(SUBMITTED)
+    timeline = _timeline(conn)
+    monkeypatch.setattr(
+        Timeline, "_upload_timeline_data", lambda self, json_str: "https://x/timeline.json"
+    )
+    monkeypatch.setattr("videodb.editor.MAX_PAYLOAD_SIZE", 1)
+    timeline.export()
+    data = conn.posts[0]["data"]
+    assert data["timeline_url"] == "https://x/timeline.json"
+    assert "timeline" not in data
+
+
+def test_the_inline_threshold_is_the_one_the_render_path_uses():
+    """Two different thresholds would mean a timeline that renders and does not
+    export, for no reason a caller could discover."""
+    assert MAX_PAYLOAD_SIZE == 100 * 1024
+
+
+def test_a_response_without_a_job_id_is_an_error_not_a_broken_job():
+    """A job object with no id cannot be polled, refreshed or downloaded. Failing
+    at the call site names the problem; returning one defers it to whichever
+    attribute is touched first."""
+    conn = StubConnection({"status": "queued"})
+    with pytest.raises(ValueError, match="job_id"):
+        _timeline(conn).export()
+
+
+# -------------------------------------------------------------- following it
+
+
+def test_refresh_reads_the_job_and_updates_in_place():
+    conn = StubConnection({"job_id": "exp_a", "status": "rendering", "progress": 40})
+    job = ExportJob(conn, job_id="exp_a", status="queued", progress=0)
+    job.refresh()
+    assert conn.gets[0]["path"] == "editor/export/exp_a"
+    assert job.status == "rendering"
+    assert job.progress == 40
+
+
+def test_done_and_failed_describe_the_two_terminal_states():
+    conn = StubConnection()
+    assert ExportJob(conn, job_id="a", status="done").done is True
+    assert ExportJob(conn, job_id="a", status="error").failed is True
+    assert ExportJob(conn, job_id="a", status="rendering").done is False
+    assert ExportJob(conn, job_id="a", status="rendering").failed is False
+
+
+def test_an_unknown_status_is_neither_done_nor_failed():
+    """The platform's status vocabulary can grow. Reporting an unrecognised
+    status as done would have a caller download an artifact that is not there."""
+    job = ExportJob(StubConnection(), job_id="a", status="transmogrifying")
+    assert job.done is False
+    assert job.failed is False
+
+
+def test_wait_polls_until_terminal():
+    conn = StubConnection(
+        {"job_id": "exp_a", "status": "rendering", "progress": 10},
+        {"job_id": "exp_a", "status": "packaging", "progress": 80},
+        {"job_id": "exp_a", "status": "done", "progress": 100},
+    )
+    job = ExportJob(conn, job_id="exp_a", status="queued")
+    job.wait(poll_interval=0)
+    assert job.status == "done"
+    assert len(conn.gets) == 3
+
+
+def test_wait_returns_on_a_failed_job_rather_than_polling_forever():
+    conn = StubConnection({"job_id": "exp_a", "status": "error"})
+    job = ExportJob(conn, job_id="exp_a", status="queued")
+    assert job.wait(poll_interval=0).failed is True
+
+
+def test_wait_gives_up_and_says_so():
+    """Silently returning a still-running job would have the caller treat an
+    unfinished export as finished."""
+    conn = StubConnection(*[{"job_id": "exp_a", "status": "rendering"}] * 50)
+    job = ExportJob(conn, job_id="exp_a", status="queued")
+    with pytest.raises(TimeoutError):
+        job.wait(timeout=0, poll_interval=0)
+
+
+def test_download_url_is_a_method_because_the_link_expires():
+    """A property invites caching, and what would be cached is a signed URL with
+    a short life. Minted per call, never stored on the job."""
+    conn = StubConnection({"download_url": "https://storage/bundle.zip?sig=1"})
+    job = ExportJob(conn, job_id="exp_a", status="done")
+    assert job.download_url() == "https://storage/bundle.zip?sig=1"
+    assert not hasattr(job, "_download_url")
+
+
+def test_download_url_refuses_before_the_job_is_done():
+    """There is nothing to sign yet, and a 410 from the platform is a worse
+    explanation than the one available here."""
+    job = ExportJob(StubConnection(), job_id="exp_a", status="rendering")
+    with pytest.raises(ValueError, match="not finished"):
+        job.download_url()
+
+
+def test_the_fidelity_summary_reaches_the_caller():
+    """An export that dropped the user's colour grades is not a plain success,
+    and a client that cannot see that reports it as one."""
+    conn = StubConnection(
+        {
+            "job_id": "exp_a",
+            "status": "done",
+            "fidelity": {"counts": {"carried": 11, "dropped": 1}, "missing_media": []},
+        }
+    )
+    job = ExportJob(conn, job_id="exp_a", status="queued")
+    job.refresh()
+    assert job.fidelity["counts"]["dropped"] == 1

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -15,6 +15,11 @@ exports a long timeline.
 import pytest
 
 from videodb.editor import MAX_PAYLOAD_SIZE, Timeline
+from videodb.exceptions import (
+    InvalidRequestError,
+    RequestTimeoutError,
+    VideodbError,
+)
 from videodb.export import ExportJob
 
 
@@ -129,7 +134,7 @@ def test_a_response_without_a_job_id_is_an_error_not_a_broken_job():
     at the call site names the problem; returning one defers it to whichever
     attribute is touched first."""
     conn = StubConnection({"status": "queued"})
-    with pytest.raises(ValueError, match="job_id"):
+    with pytest.raises(InvalidRequestError, match="job_id"):
         _timeline(conn).export()
 
 
@@ -184,7 +189,7 @@ def test_wait_gives_up_and_says_so():
     unfinished export as finished."""
     conn = StubConnection(*[{"job_id": "exp_a", "status": "rendering"}] * 50)
     job = ExportJob(conn, job_id="exp_a", timeline_id="tl-9", status="queued")
-    with pytest.raises(TimeoutError):
+    with pytest.raises(RequestTimeoutError):
         job.wait(timeout=0, poll_interval=0)
 
 
@@ -201,7 +206,7 @@ def test_download_url_refuses_before_the_job_is_done():
     """There is nothing to sign yet, and a 410 from the platform is a worse
     explanation than the one available here."""
     job = ExportJob(StubConnection(), job_id="exp_a", status="rendering")
-    with pytest.raises(ValueError, match="not finished"):
+    with pytest.raises(InvalidRequestError, match="not finished"):
         job.download_url()
 
 
@@ -221,8 +226,8 @@ def test_the_fidelity_summary_reaches_the_caller():
 
 
 def test_a_job_read_back_is_addressed_under_its_timeline():
-    """The read is scoped by timeline, which is what makes another user's job id
-    a 404 rather than a leak on the platform side."""
+    """The read is addressed under the timeline that produced the job — the
+    path shape the API defines."""
     conn = StubConnection({"job_id": "exp_a", "status": "done"})
     ExportJob(conn, job_id="exp_a", timeline_id="tl-9").refresh()
     assert conn.gets[0]["path"] == "editor/export/tl-9/exp_a"
@@ -232,7 +237,7 @@ def test_a_job_without_a_timeline_says_so_rather_than_guessing():
     """A submit response that carried no timeline_id yields a job that cannot be
     read back. Failing with that sentence beats a 404 from a malformed path."""
     job = ExportJob(StubConnection(), job_id="exp_a")
-    with pytest.raises(ValueError, match="timeline_id"):
+    with pytest.raises(InvalidRequestError, match="timeline_id"):
         job.refresh()
 
 
@@ -251,5 +256,45 @@ def test_download_url_raises_rather_than_returning_none():
     job = ExportJob(conn, SUBMITTED["job_id"], timeline_id=SUBMITTED["timeline_id"],
                     status="done")
 
-    with pytest.raises(ValueError, match="no download URL"):
+    with pytest.raises(InvalidRequestError, match="no download URL"):
         job.download_url()
+
+
+def test_every_export_failure_is_a_videodb_error():
+    """The package promises `except VideodbError` catches SDK failures, and
+    GenerationJob keeps that promise — a sibling raising builtins alongside it
+    means the documented catch-all handles one job type and crashes on the
+    other. Public surface: the types must be right at first release."""
+    job = ExportJob(StubConnection(), job_id="exp_a")
+    with pytest.raises(VideodbError):
+        job.refresh()  # no timeline_id
+    slow = StubConnection(*[{"job_id": "exp_a", "status": "rendering"}] * 5)
+    running = ExportJob(slow, job_id="exp_a", timeline_id="tl-9")
+    with pytest.raises(VideodbError):
+        running.wait(timeout=0, poll_interval=0)
+
+
+def test_a_submit_answering_id_instead_of_job_id_still_makes_a_job():
+    """GenerationJob.from_data accepts either key, and endpoints have answered
+    with both shapes. A submit that hard-fails AFTER the job was created costs
+    the user a running export they cannot see."""
+    conn = StubConnection({"id": "exp_b", "timeline_id": "tl-9", "status": "queued"})
+    job = _timeline(conn).export()
+    assert job.id == "exp_b"
+
+
+def test_job_id_is_an_alias_for_id():
+    """GenerationJob exposes both spellings; a caller moving between the two
+    job types should not need to remember which one this is."""
+    job = ExportJob(StubConnection(), job_id="exp_a")
+    assert job.job_id == "exp_a"
+
+
+def test_the_export_annotation_resolves():
+    """`-> "ExportJob"` with no import in scope breaks every annotation
+    resolver (typeguard, sphinx, pydantic) that calls get_type_hints on a
+    public method."""
+    import typing
+
+    hints = typing.get_type_hints(Timeline.export)
+    assert hints["return"].__name__ == "ExportJob"

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -48,7 +48,7 @@ def _timeline(conn):
     return Timeline(conn)
 
 
-SUBMITTED = {"job_id": "exp_abc123def456", "status": "queued", "progress": 0}
+SUBMITTED = {"job_id": "exp_abc123def456", "timeline_id": "tl-9", "status": "queued", "progress": 0}
 
 
 # ------------------------------------------------------------------- submit
@@ -138,25 +138,25 @@ def test_a_response_without_a_job_id_is_an_error_not_a_broken_job():
 
 def test_refresh_reads_the_job_and_updates_in_place():
     conn = StubConnection({"job_id": "exp_a", "status": "rendering", "progress": 40})
-    job = ExportJob(conn, job_id="exp_a", status="queued", progress=0)
+    job = ExportJob(conn, job_id="exp_a", timeline_id="tl-9", status="queued", progress=0)
     job.refresh()
-    assert conn.gets[0]["path"] == "editor/export/exp_a"
+    assert conn.gets[0]["path"] == "editor/export/tl-9/exp_a"
     assert job.status == "rendering"
     assert job.progress == 40
 
 
 def test_done_and_failed_describe_the_two_terminal_states():
     conn = StubConnection()
-    assert ExportJob(conn, job_id="a", status="done").done is True
-    assert ExportJob(conn, job_id="a", status="error").failed is True
-    assert ExportJob(conn, job_id="a", status="rendering").done is False
-    assert ExportJob(conn, job_id="a", status="rendering").failed is False
+    assert ExportJob(conn, job_id="a", timeline_id="tl-9", status="done").done is True
+    assert ExportJob(conn, job_id="a", timeline_id="tl-9", status="error").failed is True
+    assert ExportJob(conn, job_id="a", timeline_id="tl-9", status="rendering").done is False
+    assert ExportJob(conn, job_id="a", timeline_id="tl-9", status="rendering").failed is False
 
 
 def test_an_unknown_status_is_neither_done_nor_failed():
     """The platform's status vocabulary can grow. Reporting an unrecognised
     status as done would have a caller download an artifact that is not there."""
-    job = ExportJob(StubConnection(), job_id="a", status="transmogrifying")
+    job = ExportJob(StubConnection(), job_id="a", timeline_id="tl-9", status="transmogrifying")
     assert job.done is False
     assert job.failed is False
 
@@ -167,7 +167,7 @@ def test_wait_polls_until_terminal():
         {"job_id": "exp_a", "status": "packaging", "progress": 80},
         {"job_id": "exp_a", "status": "done", "progress": 100},
     )
-    job = ExportJob(conn, job_id="exp_a", status="queued")
+    job = ExportJob(conn, job_id="exp_a", timeline_id="tl-9", status="queued")
     job.wait(poll_interval=0)
     assert job.status == "done"
     assert len(conn.gets) == 3
@@ -175,7 +175,7 @@ def test_wait_polls_until_terminal():
 
 def test_wait_returns_on_a_failed_job_rather_than_polling_forever():
     conn = StubConnection({"job_id": "exp_a", "status": "error"})
-    job = ExportJob(conn, job_id="exp_a", status="queued")
+    job = ExportJob(conn, job_id="exp_a", timeline_id="tl-9", status="queued")
     assert job.wait(poll_interval=0).failed is True
 
 
@@ -183,7 +183,7 @@ def test_wait_gives_up_and_says_so():
     """Silently returning a still-running job would have the caller treat an
     unfinished export as finished."""
     conn = StubConnection(*[{"job_id": "exp_a", "status": "rendering"}] * 50)
-    job = ExportJob(conn, job_id="exp_a", status="queued")
+    job = ExportJob(conn, job_id="exp_a", timeline_id="tl-9", status="queued")
     with pytest.raises(TimeoutError):
         job.wait(timeout=0, poll_interval=0)
 
@@ -192,7 +192,7 @@ def test_download_url_is_a_method_because_the_link_expires():
     """A property invites caching, and what would be cached is a signed URL with
     a short life. Minted per call, never stored on the job."""
     conn = StubConnection({"download_url": "https://storage/bundle.zip?sig=1"})
-    job = ExportJob(conn, job_id="exp_a", status="done")
+    job = ExportJob(conn, job_id="exp_a", timeline_id="tl-9", status="done")
     assert job.download_url() == "https://storage/bundle.zip?sig=1"
     assert not hasattr(job, "_download_url")
 
@@ -215,6 +215,27 @@ def test_the_fidelity_summary_reaches_the_caller():
             "fidelity": {"counts": {"carried": 11, "dropped": 1}, "missing_media": []},
         }
     )
-    job = ExportJob(conn, job_id="exp_a", status="queued")
+    job = ExportJob(conn, job_id="exp_a", timeline_id="tl-9", status="queued")
     job.refresh()
     assert job.fidelity["counts"]["dropped"] == 1
+
+
+def test_a_job_read_back_is_addressed_under_its_timeline():
+    """The read is scoped by timeline, which is what makes another user's job id
+    a 404 rather than a leak on the platform side."""
+    conn = StubConnection({"job_id": "exp_a", "status": "done"})
+    ExportJob(conn, job_id="exp_a", timeline_id="tl-9").refresh()
+    assert conn.gets[0]["path"] == "editor/export/tl-9/exp_a"
+
+
+def test_a_job_without_a_timeline_says_so_rather_than_guessing():
+    """A submit response that carried no timeline_id yields a job that cannot be
+    read back. Failing with that sentence beats a 404 from a malformed path."""
+    job = ExportJob(StubConnection(), job_id="exp_a")
+    with pytest.raises(ValueError, match="timeline_id"):
+        job.refresh()
+
+
+def test_the_submitted_job_remembers_its_timeline():
+    conn = StubConnection(SUBMITTED)
+    assert _timeline(conn).export().timeline_id == "tl-9"

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -102,9 +102,9 @@ def test_supplied_fields_are_forwarded():
 def test_a_large_timeline_is_uploaded_rather_than_posted_inline(monkeypatch):
     """The reason to mirror generate_stream rather than invent a shape.
 
-    These requests cross an API gateway with a hard body cap, so a long timeline
-    posted inline fails at the edge with nothing useful in the response. The
-    render path already solved this; export inherits the solution.
+    A long timeline can exceed the request body limit, and posting it inline
+    then fails with nothing useful in the response. generate_stream already
+    solved this by uploading and referencing by URL; export inherits it.
     """
     conn = StubConnection(SUBMITTED)
     timeline = _timeline(conn)

--- a/videodb/__init__.py
+++ b/videodb/__init__.py
@@ -32,6 +32,7 @@ from videodb.client import Connection
 from videodb.search import AskResponse, SearchResponse, SearchResult
 from videodb.understanding import Understanding, UnderstandingAnalyzer
 from videodb.job import GenerationJob
+from videodb.export import ExportJob
 from videodb.sandbox import Sandbox
 from videodb.voice_clone import VoiceClone
 from videodb.capture_session import CaptureSession
@@ -51,6 +52,7 @@ logger: logging.Logger = logging.getLogger("videodb")
 __all__ = [
     "connect",
     "CaptureSession",
+    "ExportJob",
     "GenerationJob",
     "Sandbox",
     "VoiceClone",

--- a/videodb/editor.py
+++ b/videodb/editor.py
@@ -7,6 +7,7 @@ from enum import Enum
 
 from videodb._constants import ApiPath
 from videodb._upload import upload_bytes
+from videodb.export import ExportJob, job_from_response
 from videodb._utils._video import build_iframe_embed_code
 from videodb.exceptions import InvalidRequestError
 
@@ -1172,8 +1173,6 @@ class Timeline:
         :return: The submitted job
         :rtype: :class:`videodb.export.ExportJob`
         """
-        from videodb.export import job_from_response
-
         timeline_data = self.to_json()
         json_str = json.dumps(timeline_data)
 
@@ -1195,7 +1194,7 @@ class Timeline:
 
         return job_from_response(
             self.connection,
-            self.connection.post(path=f"{ApiPath.editor}/export", data=data),
+            self.connection.post(path=f"{ApiPath.editor}/{ApiPath.export}", data=data),
         )
 
     def _upload_timeline_data(self, json_str: str) -> str:

--- a/videodb/editor.py
+++ b/videodb/editor.py
@@ -1158,9 +1158,8 @@ class Timeline:
 
         The payload is the same shape :meth:`generate_stream` sends, including the
         fallback that uploads the timeline JSON when it exceeds
-        ``MAX_PAYLOAD_SIZE`` — these requests cross a gateway with a hard body cap,
-        and a long timeline posted inline fails at the edge with nothing useful in
-        the response.
+        ``MAX_PAYLOAD_SIZE``. A long timeline posted inline can exceed the request
+        body limit, so it is uploaded and referenced by URL instead.
 
         :param str format: Bundle format. Named rather than assumed so a second
             format is additive (default ``"nle"``)

--- a/videodb/editor.py
+++ b/videodb/editor.py
@@ -1140,6 +1140,65 @@ class Timeline:
         self.player_url = stream_data.get("player_url")
         return stream_data.get("stream_url", None)
 
+    def export(
+        self,
+        format: str = "nle",
+        name: str = None,
+        client_ref: str = None,
+        timeline_id: str = None,
+    ) -> "ExportJob":
+        """Export this timeline as an editable NLE project bundle.
+
+        Produces a zip containing FCP7 XML, OTIO, EDL, captions and the media the
+        sequence references — a project a human opens in Premiere, rather than a
+        rendered video.
+
+        The work is minutes of downloads and encoding, so this submits and returns
+        immediately. Poll the returned job, or call its ``wait()``.
+
+        The payload is the same shape :meth:`generate_stream` sends, including the
+        fallback that uploads the timeline JSON when it exceeds
+        ``MAX_PAYLOAD_SIZE`` — these requests cross a gateway with a hard body cap,
+        and a long timeline posted inline fails at the edge with nothing useful in
+        the response.
+
+        :param str format: Bundle format. Named rather than assumed so a second
+            format is additive (default ``"nle"``)
+        :param str name: Sequence name in the NLE's project panel. Falls back to the
+            timeline id — an unnamed sequence is a worse import than an ugly one
+        :param str client_ref: Your own identifier, echoed back on the job, so you
+            never have to hold ours to correlate
+        :param str timeline_id: Your identifier for this timeline. The platform
+            assigns one when omitted
+        :return: The submitted job
+        :rtype: :class:`videodb.export.ExportJob`
+        """
+        from videodb.export import job_from_response
+
+        timeline_data = self.to_json()
+        json_str = json.dumps(timeline_data)
+
+        if len(json_str.encode("utf-8")) > MAX_PAYLOAD_SIZE:
+            data = {"timeline_url": self._upload_timeline_data(json_str)}
+        else:
+            data = dict(timeline_data)
+
+        data["format"] = format
+        # Omitted rather than sent as null: absent means "fall back to the
+        # timeline id", null means "there is no name", and those differ.
+        for key, value in (
+            ("name", name),
+            ("client_ref", client_ref),
+            ("timeline_id", timeline_id),
+        ):
+            if value is not None:
+                data[key] = value
+
+        return job_from_response(
+            self.connection,
+            self.connection.post(path=f"{ApiPath.editor}/export", data=data),
+        )
+
     def _upload_timeline_data(self, json_str: str) -> str:
         """Upload timeline JSON data as a file and return the URL.
 

--- a/videodb/export.py
+++ b/videodb/export.py
@@ -1,0 +1,162 @@
+"""Following an NLE export job.
+
+An export is minutes of multi-gigabyte downloads and encoding, so it cannot be a
+synchronous call. :meth:`videodb.editor.Timeline.export` submits and returns one
+of these immediately; the caller polls, or calls :meth:`ExportJob.wait`.
+
+Two shape decisions worth stating, because both are easy to get backwards.
+
+**``download_url`` is a method, not a property.** What it returns is a signed URL
+with a short life. A property invites caching, and a cached signed URL is a link
+that works in testing and 403s a day later. It is minted per call and never held
+on the job.
+
+**``done`` and ``failed`` are both False for a status this client does not
+recognise.** The platform's vocabulary can grow, and reporting an unknown status
+as done would have a caller fetch an artifact that does not exist. Waiting on a
+status we cannot interpret is the recoverable mistake.
+"""
+
+import time
+from typing import Optional
+
+from videodb._constants import ApiPath
+
+#: Statuses that mean the job is over. Mirrors the export service's vocabulary.
+DONE = "done"
+ERROR = "error"
+TERMINAL_STATUSES = (DONE, ERROR)
+
+#: Default ceiling for :meth:`ExportJob.wait`, in seconds. Matches the export
+#: service's own per-job budget — waiting longer than the job can possibly run
+#: only delays the disappointment.
+DEFAULT_WAIT_TIMEOUT = 1800
+
+#: How often :meth:`ExportJob.wait` polls, in seconds. The job takes minutes;
+#: polling faster than this costs requests and buys nothing.
+DEFAULT_POLL_INTERVAL = 5
+
+
+class ExportJob:
+    """A submitted export.
+
+    :ivar str id: The platform's job id
+    :ivar str status: ``queued``, ``rendering``, ``converting``, ``packaging``,
+        ``done`` or ``error``
+    :ivar int progress: 0-100
+    :ivar str stage: Human-readable label for the current stage
+    :ivar str error: Failure message, when ``status`` is ``error``
+    :ivar dict fidelity: What the bundle could and could not carry
+    """
+
+    def __init__(
+        self,
+        connection,
+        job_id: str,
+        status: Optional[str] = None,
+        progress: Optional[int] = None,
+        stage: Optional[str] = None,
+        error: Optional[str] = None,
+        fidelity: Optional[dict] = None,
+        **kwargs,
+    ) -> None:
+        self.connection = connection
+        self.id = job_id
+        self.status = status
+        self.progress = progress
+        self.stage = stage
+        self.error = error
+        self.fidelity = fidelity
+
+    def __repr__(self) -> str:
+        return f"ExportJob(id={self.id!r}, status={self.status!r}, progress={self.progress!r})"
+
+    @property
+    def done(self) -> bool:
+        """Whether the export finished successfully."""
+        return self.status == DONE
+
+    @property
+    def failed(self) -> bool:
+        """Whether the export ended in failure."""
+        return self.status == ERROR
+
+    @property
+    def terminal(self) -> bool:
+        """Whether the job is over, either way."""
+        return self.status in TERMINAL_STATUSES
+
+    def refresh(self) -> "ExportJob":
+        """Re-read the job and update this object in place.
+
+        :return: self, so it can be chained
+        :rtype: :class:`ExportJob`
+        """
+        data = self.connection.get(path=f"{ApiPath.editor}/export/{self.id}") or {}
+        self.status = data.get("status", self.status)
+        self.progress = data.get("progress", self.progress)
+        self.stage = data.get("stage", self.stage)
+        self.error = data.get("error", self.error)
+        if data.get("fidelity") is not None:
+            self.fidelity = data["fidelity"]
+        return self
+
+    def wait(
+        self,
+        timeout: int = DEFAULT_WAIT_TIMEOUT,
+        poll_interval: int = DEFAULT_POLL_INTERVAL,
+    ) -> "ExportJob":
+        """Poll until the job is over.
+
+        Returns on failure as well as success — ``error`` is a terminal state, and
+        polling a failed job forever is not more helpful than reporting it.
+
+        :param int timeout: Seconds to wait before giving up
+        :param int poll_interval: Seconds between polls
+        :raises TimeoutError: if the job is still running when the budget runs out
+        :return: self
+        :rtype: :class:`ExportJob`
+        """
+        deadline = time.monotonic() + timeout
+        while True:
+            self.refresh()
+            if self.terminal:
+                return self
+            if time.monotonic() >= deadline:
+                # Raised rather than returned: a caller handed a still-running job
+                # by a method named `wait` will treat it as finished.
+                raise TimeoutError(
+                    f"export {self.id} was still {self.status!r} after {timeout}s"
+                )
+            time.sleep(poll_interval)
+
+    def download_url(self) -> str:
+        """A signed URL for the bundle, minted for this call.
+
+        Not cached and not stored on the job — see the module docstring.
+
+        :raises ValueError: if the job has not finished
+        :return: A URL valid for a limited time
+        :rtype: str
+        """
+        if not self.done:
+            raise ValueError(
+                f"export {self.id} is not finished (status {self.status!r}); "
+                "there is no bundle to download yet"
+            )
+        data = self.connection.get(path=f"{ApiPath.editor}/export/{self.id}/download") or {}
+        return data.get("download_url")
+
+
+def job_from_response(connection, data: dict) -> ExportJob:
+    """Build an :class:`ExportJob` from a submit response.
+
+    A response without a ``job_id`` is an error rather than a job: an
+    :class:`ExportJob` with no id cannot be refreshed, waited on or downloaded,
+    so failing here names the problem instead of deferring it to whichever
+    attribute the caller touches first.
+    """
+    job_id = (data or {}).get("job_id")
+    if not job_id:
+        raise ValueError(f"export response carried no job_id: {data!r}")
+    return ExportJob(connection, **{**data, "job_id": job_id})

--- a/videodb/export.py
+++ b/videodb/export.py
@@ -41,6 +41,7 @@ class ExportJob:
     """A submitted export.
 
     :ivar str id: The platform's job id
+    :ivar str timeline_id: The timeline this export was made from
     :ivar str status: ``queued``, ``rendering``, ``converting``, ``packaging``,
         ``done`` or ``error``
     :ivar int progress: 0-100
@@ -53,6 +54,7 @@ class ExportJob:
         self,
         connection,
         job_id: str,
+        timeline_id: Optional[str] = None,
         status: Optional[str] = None,
         progress: Optional[int] = None,
         stage: Optional[str] = None,
@@ -62,6 +64,10 @@ class ExportJob:
     ) -> None:
         self.connection = connection
         self.id = job_id
+        # Part of the address, not decoration. An export is read back under the
+        # timeline that produced it, which is what scopes the read to its owner —
+        # a job id alone would have to be trusted on its own.
+        self.timeline_id = timeline_id
         self.status = status
         self.progress = progress
         self.stage = stage
@@ -70,6 +76,15 @@ class ExportJob:
 
     def __repr__(self) -> str:
         return f"ExportJob(id={self.id!r}, status={self.status!r}, progress={self.progress!r})"
+
+    def _path(self) -> str:
+        """Where this job lives. The timeline scopes the read to its owner."""
+        if not self.timeline_id:
+            raise ValueError(
+                f"export {self.id} has no timeline_id, so it cannot be read back; "
+                "it was built from a response that did not carry one"
+            )
+        return f"{ApiPath.editor}/export/{self.timeline_id}/{self.id}"
 
     @property
     def done(self) -> bool:
@@ -92,7 +107,7 @@ class ExportJob:
         :return: self, so it can be chained
         :rtype: :class:`ExportJob`
         """
-        data = self.connection.get(path=f"{ApiPath.editor}/export/{self.id}") or {}
+        data = self.connection.get(path=self._path()) or {}
         self.status = data.get("status", self.status)
         self.progress = data.get("progress", self.progress)
         self.stage = data.get("stage", self.stage)
@@ -144,7 +159,7 @@ class ExportJob:
                 f"export {self.id} is not finished (status {self.status!r}); "
                 "there is no bundle to download yet"
             )
-        data = self.connection.get(path=f"{ApiPath.editor}/export/{self.id}/download") or {}
+        data = self.connection.get(path=f"{self._path()}/download") or {}
         return data.get("download_url")
 
 

--- a/videodb/export.py
+++ b/videodb/export.py
@@ -21,6 +21,7 @@ import time
 from typing import Optional
 
 from videodb._constants import ApiPath
+from videodb.exceptions import InvalidRequestError, RequestTimeoutError
 
 #: Statuses that mean the job is over.
 DONE = "done"
@@ -62,11 +63,10 @@ class ExportJob:
         fidelity: Optional[dict] = None,
         **kwargs,
     ) -> None:
-        self.connection = connection
+        self._connection = connection
         self.id = job_id
-        # Part of the address, not decoration. An export is read back under the
-        # timeline that produced it, which is what scopes the read to its owner —
-        # a job id alone would have to be trusted on its own.
+        # Part of the address, not decoration: an export is read back under
+        # the timeline that produced it.
         self.timeline_id = timeline_id
         self.status = status
         self.progress = progress
@@ -77,14 +77,21 @@ class ExportJob:
     def __repr__(self) -> str:
         return f"ExportJob(id={self.id!r}, status={self.status!r}, progress={self.progress!r})"
 
+    @property
+    def job_id(self) -> str:
+        """Alias for :attr:`id` — :class:`videodb.job.GenerationJob` exposes
+        both spellings, and a caller moving between the two job types should
+        not need to remember which one this is."""
+        return self.id
+
     def _path(self) -> str:
         """Where this job lives. The timeline scopes the read to its owner."""
         if not self.timeline_id:
-            raise ValueError(
+            raise InvalidRequestError(
                 f"export {self.id} has no timeline_id, so it cannot be read back; "
                 "it was built from a response that did not carry one"
             )
-        return f"{ApiPath.editor}/export/{self.timeline_id}/{self.id}"
+        return f"{ApiPath.editor}/{ApiPath.export}/{self.timeline_id}/{self.id}"
 
     @property
     def done(self) -> bool:
@@ -107,7 +114,7 @@ class ExportJob:
         :return: self, so it can be chained
         :rtype: :class:`ExportJob`
         """
-        data = self.connection.get(path=self._path()) or {}
+        data = self._connection.get(path=self._path()) or {}
         self.status = data.get("status", self.status)
         self.progress = data.get("progress", self.progress)
         self.stage = data.get("stage", self.stage)
@@ -128,7 +135,8 @@ class ExportJob:
 
         :param int timeout: Seconds to wait before giving up
         :param int poll_interval: Seconds between polls
-        :raises TimeoutError: if the job is still running when the budget runs out
+        :raises RequestTimeoutError: if the job is still running when the
+            budget runs out
         :return: self
         :rtype: :class:`ExportJob`
         """
@@ -140,7 +148,7 @@ class ExportJob:
             if time.monotonic() >= deadline:
                 # Raised rather than returned: a caller handed a still-running job
                 # by a method named `wait` will treat it as finished.
-                raise TimeoutError(
+                raise RequestTimeoutError(
                     f"export {self.id} was still {self.status!r} after {timeout}s"
                 )
             time.sleep(poll_interval)
@@ -150,22 +158,22 @@ class ExportJob:
 
         Not cached and not stored on the job — see the module docstring.
 
-        :raises ValueError: if the job has not finished
+        :raises InvalidRequestError: if the job has not finished
         :return: A URL valid for a limited time
         :rtype: str
         """
         if not self.done:
-            raise ValueError(
+            raise InvalidRequestError(
                 f"export {self.id} is not finished (status {self.status!r}); "
                 "there is no bundle to download yet"
             )
-        data = self.connection.get(path=f"{self._path()}/download") or {}
+        data = self._connection.get(path=f"{self._path()}/download") or {}
         url = data.get("download_url")
         if not url:
             # Returning None from something annotated -> str pushes the failure
             # into whatever the caller does with it — an opener, a request, a
             # log line reading "None" — and by then nothing points back here.
-            raise ValueError(
+            raise InvalidRequestError(
                 f"export {self.id} finished but no download URL was returned; "
                 "the bundle may have expired"
             )
@@ -180,7 +188,8 @@ def job_from_response(connection, data: dict) -> ExportJob:
     so failing here names the problem instead of deferring it to whichever
     attribute the caller touches first.
     """
-    job_id = (data or {}).get("job_id")
+    job_id = (data or {}).get("job_id") or (data or {}).get("id")
     if not job_id:
-        raise ValueError(f"export response carried no job_id: {data!r}")
-    return ExportJob(connection, **{**data, "job_id": job_id})
+        raise InvalidRequestError(f"export response carried no job_id: {data!r}")
+    kwargs = {k: v for k, v in (data or {}).items() if k != "id"}
+    return ExportJob(connection, **{**kwargs, "job_id": job_id})

--- a/videodb/export.py
+++ b/videodb/export.py
@@ -22,14 +22,14 @@ from typing import Optional
 
 from videodb._constants import ApiPath
 
-#: Statuses that mean the job is over. Mirrors the export service's vocabulary.
+#: Statuses that mean the job is over.
 DONE = "done"
 ERROR = "error"
 TERMINAL_STATUSES = (DONE, ERROR)
 
-#: Default ceiling for :meth:`ExportJob.wait`, in seconds. Matches the export
-#: service's own per-job budget — waiting longer than the job can possibly run
-#: only delays the disappointment.
+#: Default ceiling for :meth:`ExportJob.wait`, in seconds. Half an hour is
+#: longer than an export is expected to take, so a wait that reaches it means
+#: something is wrong rather than slow.
 DEFAULT_WAIT_TIMEOUT = 1800
 
 #: How often :meth:`ExportJob.wait` polls, in seconds. The job takes minutes;

--- a/videodb/export.py
+++ b/videodb/export.py
@@ -160,7 +160,16 @@ class ExportJob:
                 "there is no bundle to download yet"
             )
         data = self.connection.get(path=f"{self._path()}/download") or {}
-        return data.get("download_url")
+        url = data.get("download_url")
+        if not url:
+            # Returning None from something annotated -> str pushes the failure
+            # into whatever the caller does with it — an opener, a request, a
+            # log line reading "None" — and by then nothing points back here.
+            raise ValueError(
+                f"export {self.id} finished but no download URL was returned; "
+                "the bundle may have expired"
+            )
+        return url
 
 
 def job_from_response(connection, data: dict) -> ExportJob:


### PR DESCRIPTION
# `timeline.export()` — NLE project bundles

A timeline can already be rendered to a video. This adds the other thing you might want from it: an **editable project**.

```python
job = timeline.export()          # returns immediately
job.wait()                       # or poll job.refresh()
url = job.download_url()         # short-lived link to a .zip
```

The zip holds an FCP7 XML project, an OTIO copy, an EDL, an SRT and the media the sequence references — importable with media already relinked, rather than a flat video.

**+521 lines, 0 deletions.** One new module, one method, one export from the package root.

---

## The shape

```mermaid
sequenceDiagram
    participant U as Your code
    participant T as Timeline
    participant J as ExportJob
    participant A as VideoDB

    U->>T: timeline.export()
    T->>A: POST (the same payload generate_stream sends)
    A-->>T: job id + status
    T-->>U: ExportJob
    U->>J: wait()
    loop until terminal
        J->>A: GET status
    end
    U->>J: download_url()
    J->>A: GET artifact
    A-->>J: a short-lived URL
```

Submit returns straight away because the work is minutes of downloading and encoding. Nothing is held open.

## `Timeline.export()`

```python
def export(
    self,
    format: str = "nle",
    name: str = None,
    client_ref: str = None,
    timeline_id: str = None,
) -> ExportJob
```

| Parameter | Why it exists |
| --- | --- |
| `format` | Named rather than assumed, so a second format is additive |
| `name` | The sequence name in the NLE's project panel. Falls back to the timeline id — an unnamed sequence is a worse import than an ugly one |
| `client_ref` | Your own identifier, echoed back on the job, so you never have to hold ours to correlate |
| `timeline_id` | Your identifier for this timeline; assigned for you when omitted |

The payload is the same shape `generate_stream` sends, **including the fallback that uploads the timeline JSON when it exceeds `MAX_PAYLOAD_SIZE`** — a long timeline posted inline can exceed the request body limit.

## `ExportJob` — `videodb/export.py`

| Member | Notes |
| --- | --- |
| `refresh()` | One read; returns self so it chains |
| `wait(timeout=..., poll_interval=...)` | Blocks to a terminal state |
| `done` / `failed` / `terminal` | Properties, not string comparisons at the call site |
| `download_url()` | Minted per call and short-lived by construction — never stored, so a link cannot quietly expire in your database |
| `fidelity` | What the bundle carried, approximated and dropped |

`ExportJob` is exported at the package root, so `from videodb import ExportJob` works for type annotations without reaching into a submodule.

---

## Design decisions, each with a test

**A job is read back under the timeline that produced it.** The read path is scoped by timeline, not global — a bare job id is not a lookup key.

**`download_url()` returns `str`, and now actually does.** It was annotated `str` while returning the response dict on one branch.

**Absent and null are different.** `name`, `client_ref` and `timeline_id` are omitted from the payload when unset rather than sent as `null` — absent means "fall back to the timeline id", null means "there is no name", and those are not the same request.

**The docstrings describe the SDK's behaviour, not the service behind it.** An earlier draft explained infrastructure this package has no business knowing about.

## Compatibility

Purely additive: one new module, one new method, one new package-level export. **No existing signature, return type or behaviour changes.** Nothing is deprecated.

## Requires

A VideoDB deployment where the export feature is enabled. Against one where it is not, `timeline.export()` raises the same error any unavailable endpoint does.

This PR is **not** a prerequisite for the feature working — it is a typed convenience over an endpoint that can also be called directly. It can merge before, after, or independently of the rest.

---

## Verification

`tests/test_export.py` — 255 lines, no network. Covers the payload shape including the large-timeline upload fallback, the omitted-versus-null distinction, terminal-state handling, `wait()` timeout behaviour, and `download_url()`'s return type.

### Known follow-up

`fidelity` is exposed on `ExportJob` but the status response does not currently populate it, so it reads as empty even for an export that dropped content. The field is right; the plumbing behind it is not finished.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

### Review pass (2026-08-11, `3fd76d2`)

- Failures now raise `RequestTimeoutError` / `InvalidRequestError` — the same `VideodbError` hierarchy `GenerationJob` uses, so a documented `except VideodbError` catches both job types.
- `Timeline.export`'s return annotation resolves under `typing.get_type_hints` (real top-level import; no cycle exists).
- Submit accepts `id` as well as `job_id`, matching `GenerationJob.from_data`; `.job_id` alias added; connection attribute is `_connection` like every peer; paths compose from `ApiPath.export`.
- README example gained a failure branch, and the fidelity paragraph now points at the bundle's own `fidelity.md` report.

29 tests green.
