### PR TITLE
Return the permanent url from generate_url

### DIFF
--- a/videodb/audio.py
+++ b/videodb/audio.py
@@ -14,6 +14,7 @@ class Audio:
     :ivar str collection_id: ID of the collection this audio belongs to
     :ivar str name: Name of the audio file
     :ivar float length: Duration of the audio in seconds
+    :ivar str url: Permanent url of the audio, when the server provides one
     :ivar list transcript: Timestamped transcript segments
     :ivar str transcript_text: Full transcript text
     """
@@ -26,6 +27,7 @@ class Audio:
         self.collection_id = collection_id
         self.name = kwargs.get("name", None)
         self.length = float(kwargs.get("length", 0.0))
+        self.url = kwargs.get("url", None)
         self.transcript = kwargs.get("transcript", None)
         self.transcript_text = kwargs.get("transcript_text", None)
 
@@ -39,12 +41,21 @@ class Audio:
         )
 
     def generate_url(self) -> str:
-        """Generate the signed url of the audio.
+        """Get a url for the audio.
+
+        Returns the audio's permanent url when the server provides one. That url
+        never expires, so it is safe to store; it redirects to storage, so fetch it
+        with a client that follows redirects.
+
+        Falls back to a signed storage url for audio created before permanent urls
+        existed. Those expire after a few days -- do not persist them.
 
         :raises InvalidRequestError: If the get_url fails
-        :return: The signed url of the audio
+        :return: The url of the audio
         :rtype: str
         """
+        if self.url:
+            return self.url
         url_data = self._connection.post(
             path=f"{ApiPath.audio}/{self.id}/{ApiPath.generate_url}",
             params={"collection_id": self.collection_id},

--- a/videodb/image.py
+++ b/videodb/image.py
@@ -29,12 +29,21 @@ class Image:
         )
 
     def generate_url(self) -> str:
-        """Generate the signed url of the image.
+        """Get a url for the image.
+
+        Returns the image's permanent url when the server provides one. That url
+        never expires, so it is safe to store; it redirects to storage, so fetch it
+        with a client that follows redirects.
+
+        Falls back to a signed storage url for images created before permanent urls
+        existed. Those expire after a few days -- do not persist them.
 
         :raises InvalidRequestError: If the get_url fails
-        :return: The signed url of the image
+        :return: The url of the image
         :rtype: str
         """
+        if self.url:
+            return self.url
         url_data = self._connection.post(
             path=f"{ApiPath.image}/{self.id}/{ApiPath.generate_url}",
             params={"collection_id": self.collection_id},


### PR DESCRIPTION
Generated images and audio only ever had one address: a signed storage URL with the expiry baked in — 6 days for images, 7 for audio. Callers store what `generate_url()` returns (the Director writes it into chat history), so on day 6 the link starts 403ing and nothing can renew it. Linear ENG-1278.

The server side is deployed on dev: each image and audio asset now has a permanent `url` that resolves through a redirect to a URL signed on the spot, so what we hand out never carries an expiry of its own.

This makes `generate_url()` prefer that permanent url, falling back to the signed one for assets created before it existed. Doing it here rather than asking callers to switch to `.url` fixes the whole install base without anyone editing code — and skips a round trip that is limit-checked at 10k/month per user.

`Image` already had a `url` attribute; `Audio` did not and gains one.

## Behaviour change — worth a version bump, not a silent swap

The returned url is now a **redirect** rather than a direct storage url. Verified against dev:

- Clients that follow redirects are fine (`requests`, browsers, ffmpeg). A bare `curl` without `-L` is not.
- `HEAD` returns the redirect's `content-length` (~2.3KB), **not** the object's size. Anything sizing a file that way silently gets a wrong number.
- Code that parses the url — host checks, extracting the storage path, stripping query params — will not find what it expects.
- Asset fetches now depend on the API being reachable; the old signed url went straight to storage.

Not a regression: CORS. The old url had no `Access-Control-Allow-Origin` either, so `fetch()` was already blocked both ways.

## Tested against dev

```
image.generate_url() -> https://api.dev.videodb.io/a/at-rgUApXrrhCU5Hr3EpRdxFA.png
audio.url            -> https://api.dev.videodb.io/a/at-1y2HCk6ev5tcLwkaKJpB0g.mp3
audio.generate_url() -> https://api.dev.videodb.io/a/at-1y2HCk6ev5tcLwkaKJpB0g.mp3
```

Fetching one of those returns `content-type: audio/mpeg` with `content-disposition: inline; filename="Permanent Asset Links Live.mp3"`, and the signature behind it lives ~7 hours instead of 6–7 days.

Server PRs, both merged and deployed to dev: Spext/videodb-server#953 and Spext/storage_core#162.